### PR TITLE
Add DISPARAR button to trigger n8n webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ NOCODB_TABLE=m1kkxdnyftu2uaa
 AUTH_USER=admin
 AUTH_PASS=admin123
 AUTH_SECRET=uma-chave-segura
+N8N_WEBHOOK_URL=https://webhook-n8n.ricco.digital/webhook/disparos-dicacell

--- a/pages/index.js
+++ b/pages/index.js
@@ -43,6 +43,8 @@ export default function Home() {
   const [importText, setImportText] = useState('');
   const [submitLoading, setSubmitLoading] = useState(false);
   const [submitError, setSubmitError] = useState('');
+  const [triggering, setTriggering] = useState(false);
+  const [triggerError, setTriggerError] = useState('');
 
   const hidden = useMemo(() => new Set(readLocal('templatesHidden', [])), [tplTick]);
   const templates = useMemo(() => {
@@ -149,6 +151,20 @@ export default function Home() {
     } catch { setAuthed(false); }
   }
   async function logout() { await fetch('/api/logout'); setAuthed(false); }
+
+  async function triggerDisparos() {
+    setTriggering(true);
+    setTriggerError('');
+    try {
+      await fetchJSON('/api/n8n/trigger', { method: 'POST', body: JSON.stringify({}) });
+      await load();
+    } catch (err) {
+      console.error(err);
+      setTriggerError(err?.message || 'Falha ao disparar');
+    } finally {
+      setTriggering(false);
+    }
+  }
 
   function toggleTheme() {
     const next = theme === 'light' ? 'dark' : 'light';
@@ -270,8 +286,10 @@ export default function Home() {
                 <option value="pendente">Pendentes</option>
                 <option value="enviado">Enviados</option>
               </select>
+              <button className="btn-primary flex-shrink-0" onClick={triggerDisparos} disabled={triggering}>{triggering ? 'Disparando…' : 'DISPARAR'}</button>
             </div>
           </div>
+          {triggerError && (<div className="tag !text-red-300 !border-red-500/40 mb-4">{triggerError}</div>)}
 
           <div className="overflow-x-auto">
             <table className="w-full text-sm">


### PR DESCRIPTION
## Summary
- show error feedback when n8n webhook trigger fails
- add "DISPARAR" action in Envios to post to n8n webhook and refresh list

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a088ce94083329e951cf747f0532e