### PR TITLE
Add DISPARAR button to trigger n8n webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ NOCODB_TABLE=m1kkxdnyftu2uaa
 AUTH_USER=admin
 AUTH_PASS=admin123
 AUTH_SECRET=uma-chave-segura
+N8N_WEBHOOK_URL=https://webhook-n8n.ricco.digital/webhook/disparos-dicacell

--- a/pages/index.js
+++ b/pages/index.js
@@ -43,6 +43,8 @@ export default function Home() {
   const [importText, setImportText] = useState('');
   const [submitLoading, setSubmitLoading] = useState(false);
   const [submitError, setSubmitError] = useState('');
+  const [triggering, setTriggering] = useState(false);
+  const [triggerError, setTriggerError] = useState('');
 
   const hidden = useMemo(() => new Set(readLocal('templatesHidden', [])), [tplTick]);
   const templates = useMemo(() => {
@@ -149,6 +151,20 @@ export default function Home() {
     } catch { setAuthed(false); }
   }
   async function logout() { await fetch('/api/logout'); setAuthed(false); }
+
+  async function triggerDisparos() {
+    setTriggering(true);
+    setTriggerError('');
+    try {
+      await fetchJSON('/api/n8n/trigger', { method: 'POST', body: JSON.stringify({}) });
+      await load();
+    } catch (err) {
+      console.error(err);
+      setTriggerError(err?.message || 'Falha ao disparar');
+    } finally {
+      setTriggering(false);
+    }
+  }
 
   function toggleTheme() {
     const next = theme === 'light' ? 'dark' : 'light';
@@ -261,9 +277,9 @@ export default function Home() {
         </section>
 
         <section className="card p-6 mt-6">
-          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3 mb-4">
+          <div className="flex flex-col gap-3 mb-4 md:flex-row md:items-center">
             <h2 className="text-xl font-semibold">Envios</h2>
-            <div className="flex items-center gap-3 w-full">
+            <div className="flex items-center gap-3 flex-1">
               <input className="input w-full md:w-96" placeholder="Buscar por nome, telefone ou template" value={q} onChange={e => setQ(e.target.value)} />
               <select className="input w-48" value={statusFilter} onChange={e => setStatusFilter(e.target.value)}>
                 <option value="__all__">Todos</option>
@@ -271,7 +287,15 @@ export default function Home() {
                 <option value="enviado">Enviados</option>
               </select>
             </div>
+            <button
+              className="btn-primary btn-danger flex-shrink-0 self-end md:self-auto md:ml-auto"
+              onClick={triggerDisparos}
+              disabled={triggering}
+            >
+              {triggering ? 'Disparando…' : 'DISPARAR'}
+            </button>
           </div>
+          {triggerError && (<div className="tag !text-red-300 !border-red-500/40 mb-4">{triggerError}</div>)}
 
           <div className="overflow-x-auto">
             <table className="w-full text-sm">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -78,6 +78,11 @@ body{
 .btn-primary:hover{ filter: brightness(1.08); }
 .btn-primary:active{ transform: translateY(1px); }
 
+.btn-danger{
+  background-image: linear-gradient(92deg, #ff3c3c, #ff7a18);
+  box-shadow: 0 8px 22px rgba(255,60,60,0.35), 0 10px 30px rgba(255,122,24,0.22);
+}
+
 .btn-soft{
   display:inline-flex; align-items:center; justify-content:center;
   padding: 11px 18px; border-radius: 16px; font-weight:500;


### PR DESCRIPTION
## Summary
- show error feedback when n8n webhook trigger fails
- add "DISPARAR" action in Envios to post to n8n webhook and refresh list
- reposition DISPARAR button and apply red gradient styling

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a088ce94083329e951cf747f0532e