### PR TITLE
Refactor send trigger button layout

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -286,8 +286,10 @@ export default function Home() {
                 <option value="pendente">Pendentes</option>
                 <option value="enviado">Enviados</option>
               </select>
-              <button className="btn-primary flex-shrink-0" onClick={triggerDisparos} disabled={triggering}>{triggering ? 'Disparando…' : 'DISPARAR'}</button>
             </div>
+          </div>
+          <div className="flex justify-end mb-4">
+            <button className="btn-primary flex-shrink-0" onClick={triggerDisparos} disabled={triggering}>{triggering ? 'Disparando…' : 'DISPARAR'}</button>
           </div>
           {triggerError && (<div className="tag !text-red-300 !border-red-500/40 mb-4">{triggerError}</div>)}
 


### PR DESCRIPTION
## Summary
- move "DISPARAR" button into its own right-aligned container above the Envios table
- remove button from filter controls while preserving trigger logic

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a2f3e0abc833281b945eed9108f7c