### PR TITLE
Fix search and status filters for record list

### DIFF
--- a/pages/api/data/list.js
+++ b/pages/api/data/list.js
@@ -2,12 +2,31 @@ import { ncFetch } from '../../../lib/nocodb';
 export default async function handler(req, res){
   try {
     const { q = '', status = '' } = req.query;
-    const where = [];
-    if (status === 'enviado') where.push(`status,eq,enviado`);
-    if (status === 'pendente') where.push(`or((status,eq,), (status,is,null))`);
-    if (q) where.push(`or((nome,like,${encodeURIComponent('%'+q+'%')}),(whatsapp,like,${encodeURIComponent('%'+q+'%')}),(nome2,like,${encodeURIComponent('%'+q+'%')}),(template,like,${encodeURIComponent('%'+q+'%')}))`);
-    const qs = where.length ? `?where=${where.join('~and~')}&limit=999` : '?limit=999';
-    const data = await ncFetch(`/records${qs}`);
-    res.json({ list: data.list || [] });
-  } catch(e){ res.status(500).json({ error: e.message }); }
+
+    // fetch all records first; dataset is small (limit 999)
+    const data = await ncFetch(`/records?limit=999`);
+    let list = data.list || [];
+
+    // filter by status
+    if (status === 'enviado') {
+      list = list.filter(r => (r.status || '').toLowerCase() === 'enviado');
+    } else if (status === 'pendente') {
+      list = list.filter(r => !(r.status || '').toLowerCase());
+    }
+
+    // search by name, phone or template
+    if (q) {
+      const qLower = q.toLowerCase();
+      list = list.filter(r => (
+        (r.nome || '').toLowerCase().includes(qLower) ||
+        (r.whatsapp || '').toLowerCase().includes(qLower) ||
+        (r.nome2 || '').toLowerCase().includes(qLower) ||
+        (r.template || '').toLowerCase().includes(qLower)
+      ));
+    }
+
+    res.json({ list });
+  } catch(e){
+    res.status(500).json({ error: e.message });
+  }
 }


### PR DESCRIPTION
## Summary
- handle record filtering and search on the server
- allow listing by status (all, enviado, pendente) and query term

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a329f7eac8332939601f33817e0e9