### PR TITLE
Fix update endpoint to include record id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+.DS_Store

--- a/pages/api/nocodb/update.js
+++ b/pages/api/nocodb/update.js
@@ -3,7 +3,11 @@ export default async function handler(req,res){
   if (req.method !== 'PATCH') return res.status(405).end();
   try {
     const { id, status } = req.body || {};
-    const out = await ncFetch(`/records`, { method: 'PATCH', body: JSON.stringify({ Id: id, status })});
+    if (!id) return res.status(400).json({ error: 'id required' });
+    const out = await ncFetch(`/records/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ status })
+    });
     res.json(out);
   } catch(e){ res.status(500).json({ error: e.message }); }
 }


### PR DESCRIPTION
## Summary
- fix update API to require id and patch specific record
- add gitignore for node artifacts

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689923b03488833283ace7010d3f9829