### PR TITLE
Fix search for name/phone/template field

### DIFF
--- a/pages/api/data/list.js
+++ b/pages/api/data/list.js
@@ -17,11 +17,12 @@ export default async function handler(req, res){
     // search by name, phone or template
     if (q) {
       const qLower = q.toLowerCase();
+      const digits = qLower.replace(/\D+/g, '');
       list = list.filter(r => (
         (r.nome || '').toLowerCase().includes(qLower) ||
-        (r.whatsapp || '').toLowerCase().includes(qLower) ||
         (r.nome2 || '').toLowerCase().includes(qLower) ||
-        (r.template || '').toLowerCase().includes(qLower)
+        (r.template || '').toLowerCase().includes(qLower) ||
+        (digits && (r.whatsapp || '').replace(/\D+/g, '').includes(digits))
       ));
     }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -62,7 +62,7 @@ export default function Home() {
       (r.nome || '').toLowerCase().includes(term) ||
       (r.nome2 || '').toLowerCase().includes(term) ||
       (r.template || '').toLowerCase().includes(term) ||
-      (r.whatsapp || '').replace(/\D+/g, '').includes(digits)
+      (digits && (r.whatsapp || '').replace(/\D+/g, '').includes(digits))
     ));
   }, [list, q]);
 


### PR DESCRIPTION
## Summary
- ensure client-side search only checks phone numbers when digits are present
- normalize phone numbers in API filtering to match digits regardless of formatting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689a44d18cf4833299db31c4374b01f9